### PR TITLE
Fix to stop passport from attempting to serialize user on invalid authentication request

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -94,13 +94,13 @@ module.exports = {
 
       if (err || !user) {
         sails.log.warn(err);
-        return tryAgain(err);
+        return tryAgain();
       }
 
       req.login(user, function (err) {
         if (err) {
           sails.log.warn(err);
-          return tryAgain(err);
+          return tryAgain();
         }
 
         // Upon successful login, send the user to the homepage where req.user

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -83,23 +83,26 @@ module.exports = {
         res.redirect('back');
       }
       else {
-        // make sure the server always returns a response to the client i.e passport-local bad username/email or password
-        res.serverError();
+        // make sure the server always returns a response to the client
+        // i.e passport-local bad username/email or password
+        res.badRequest('Bad Request');
       }
 
     }
 
     passport.callback(req, res, function (err, user) {
-      if (err) {
+
+      if (err || !user) {
         sails.log.warn(err);
-        return tryAgain();
+        return tryAgain(err);
       }
 
       req.login(user, function (err) {
         if (err) {
           sails.log.warn(err);
-          return tryAgain();
+          return tryAgain(err);
         }
+
         // Upon successful login, send the user to the homepage where req.user
         // will available.
         req.session.authenticated = true;

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -85,7 +85,7 @@ module.exports = {
       else {
         // make sure the server always returns a response to the client
         // i.e passport-local bad username/email or password
-        res.badRequest('Bad Request');
+        res.forbidden();
       }
 
     }

--- a/test/unit/controllers/AuthController.test.js
+++ b/test/unit/controllers/AuthController.test.js
@@ -28,7 +28,7 @@ describe('Auth Controller', function () {
           identifier: 'invalid@email.com',
           password: 'admin1234'
         })
-        .expect(500)
+        .expect(400)
         .end(function(err) {
           done(err);
       });
@@ -43,7 +43,7 @@ describe('Auth Controller', function () {
           identifier: 'existing.user@email.com',
           password: 'invalid1235'
         })
-        .expect(500)
+        .expect(400)
         .end(function(err) {
           done(err);
       });

--- a/test/unit/controllers/AuthController.test.js
+++ b/test/unit/controllers/AuthController.test.js
@@ -28,7 +28,7 @@ describe('Auth Controller', function () {
           identifier: 'invalid@email.com',
           password: 'admin1234'
         })
-        .expect(400)
+        .expect(403)
         .end(function(err) {
           done(err);
       });
@@ -43,7 +43,7 @@ describe('Auth Controller', function () {
           identifier: 'existing.user@email.com',
           password: 'invalid1235'
         })
-        .expect(400)
+        .expect(403)
         .end(function(err) {
           done(err);
       });


### PR DESCRIPTION
AuthController was continuing the passport workflow and attempting to serialize an invalid user. Added !user to the callback to fix this issue and updated server response to return a more appropriate status code.