### PR TITLE
Add socket auth to passport policy

### DIFF
--- a/test/unit/controllers/AuthController.test.js
+++ b/test/unit/controllers/AuthController.test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var request = require('supertest');
+var socket = require('sails.io.js');
 
 describe('Auth Controller', function () {
 
@@ -46,6 +47,41 @@ describe('Auth Controller', function () {
         .expect(403)
         .end(function(err) {
           done(err);
+      });
+
+    });
+
+    //Test with Web Sockets from sails.io
+
+    it ('passport-local authentication via web socket should succeed if email and password valid', function (done) {
+      
+      io.socket.post('/auth/local', {
+          identifier: 'existing.user@email.com',
+          password: 'admin1234'
+      }, function (resData) {
+          done(resData);
+      });
+
+    });
+
+    it ('passport-local authentication via web socket should fail and return error code if email is invalid', function (done) {
+      
+      io.socket.post('/auth/local', {
+          identifier: 'invalid@email.com',
+          password: 'admin1234'
+      }, function (resData) {
+          done(resData);
+      });
+
+    });
+
+    it ('passport-local authentication via web socket should fail and return error code if password is invalid', function (done) {
+
+      io.socket.post('/auth/local', {
+          identifier: 'existing.user@email.com',
+          password: 'invalid1234'
+      }, function (resData) {
+          done(resData);
       });
 
     });


### PR DESCRIPTION
Testing requires sails.io.js `npm install sails.io.js` but honestly, I'm not great at testing sockets.  All this PR does is add's passports authentication methods to socket requests via the passport policy. It's fairly identical to a similar sails auth generator feature request.  It's an elegant way of doing it compared to other methods such as hijacking requests through the bootstrap.  