### PR TITLE
Inconsistent handling of validation errors for local registration

### DIFF
--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -60,7 +60,7 @@ exports.createUser = function (_user, next) {
     }, function (err, passport) {
       if (err) {
         if (err.code === 'E_VALIDATION') {
-          throw new Error('Error.Passport.Password.Invalid');
+          err = new Error('Error.Passport.Password.Invalid');
         }
         
         return user.destroy(function (destroyErr) {


### PR DESCRIPTION
If you submit a form with an invalid password (e.g. too short), you get an exception (which I wasn't able to catch) instead of the default HTTP 500 in UserController. In addition, the newly created user is left hanging in the database with no matching passport (user.destroy is not called), which effectively prevents the user from registering.

I've also tried writing a test for this case, but for some reason both versions (throw and non-throw) return HTTP 500 in the test(?), although the results are different in manual testing (throw brings down sails).

(Loosely related: it seems like there is no clear way to differentiate between validation errors and "real" errors returned by this plugin?)