### PR TITLE
Replaces passport-google with passport-google-oauth due to Google's deprecation of OpenID 2.0

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -22,8 +22,13 @@ module.exports.passport = {
 
   google: {
     name: 'Google',
-    protocol: 'openid',
-    strategy: require('passport-google').Strategy
+    protocol: 'oauth2',
+    strategy: require('passport-google-oauth').OAuth2Strategy,
+    options: {
+      clientID: 'your-client-id',
+      clientSecret: 'your-client-secret',
+      scope: ['profile', 'email']
+    }
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "optionalDependencies": {
     "passport-facebook": "^1.0.3",
-    "passport-google": "^0.3.0",
+    "passport-google-oauth": "^0.2.0",
     "passport-twitter": "^1.0.2"
   },
   "bundledDependencies": [


### PR DESCRIPTION
Closes #42 