### PR TITLE
Adds ?next= param to /logout

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -18,23 +18,16 @@ module.exports = {
    * @param {Object} res
    */
   logout: function (req, res) {
-
+    req.logout();
     if (!req.isSocket) {
-
-      req.logout();
-      res.redirect('/');
-
+      res.redirect(req.query.next || '/');
     }
     else {
-
       delete req.user;
       delete req.session.passport;
       req.session.authenticated = false;
-
       res.ok();
-
     }
-
   },
 
   /**


### PR DESCRIPTION
Closes #50

Source of `req.logout` [here](https://github.com/jaredhanson/passport/blob/298d2452430dd0d1841d417e9c0d0b23e4b06239/lib/http/request.js#L58-L74). Theoretically we could remove L30/L26 if we could ensure the parameter is default.