### PR TITLE
fix docs to avoid 403 for user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ $ sails generate auth-api
   }
 ```
 
+> The policies above secure everything by default, including registration. In case you wish to open it, add the following:
+```js
+  UserController: {
+    'create': true
+  }
+```
+
 ### 3. authenticate!
 
 Create users as you normally would (`POST` to `/user`). Authenticate using the


### PR DESCRIPTION
Following the docs results in securing every url, including registration which results in being unable to do anything without creating a user straight in the DB (I guess that's obvious to be avoided).

Fixes #51 

/cc @JHereU