### PR TITLE
Use waterline-style validation errors with filtered information

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -6,11 +6,11 @@
  */
 
 module.exports = {
-  create: function (req, res) {
+  create: function (req, res, next) {
     sails.services.passport.protocols.local.register(req.body, function (err, user) {
-      if (!err) return res.ok(user);
-      if (err.message === 'Error.Passport.Password.Invalid') return res.badRequest(err);
-      return res.serverError(err);
+      if (err) return next(err);
+
+      res.ok(user);
     });
   },
 

--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -1,3 +1,5 @@
+var SAError = require('../../../lib/error/SAError.js');
+
 /**
  * Local Authentication Protocol
  *
@@ -36,18 +38,10 @@ exports.createUser = function (_user, next) {
 
   return sails.models.user.create(_user, function (err, user) {
     if (err) {
+      sails.log(err);
 
       if (err.code === 'E_VALIDATION') {
-
-        sails.log(err);
-
-        if (err.invalidAttributes.email) {
-          return next(new Error('Error.Passport.Email.Exists'));
-        }
-        else {
-          return next(new Error('Error.Passport.User.Exists'));
-        }
-
+        return next(new SAError({originalError: err}));
       }
       
       return next(err);
@@ -60,7 +54,7 @@ exports.createUser = function (_user, next) {
     }, function (err, passport) {
       if (err) {
         if (err.code === 'E_VALIDATION') {
-          err = new Error('Error.Passport.Password.Invalid');
+          err = new SAError({originalError: err});
         }
         
         return user.destroy(function (destroyErr) {

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -3,6 +3,7 @@
   "Error.Passport.Password.Wrong": "Incorrect password",
   "Error.Passport.Password.NotSet": "Password not set",
   "Error.Passport.Username.NotFound": "Username not found",
+  "Error.Passport.Username.Invalid": "Username is invalid",
   "Error.Passport.User.Exists": "Username is already taken.",
   "Error.Passport.Email.NotFound": "Email address not found",
   "Error.Passport.Email.Missing": "Email address is required",

--- a/lib/error/SAError.js
+++ b/lib/error/SAError.js
@@ -1,0 +1,110 @@
+var util = require('util');
+var _ = require('lodash');
+var errors = {
+  'email': {
+    'email': 'Error.Passport.Email.Invalid',
+    'unique': 'Error.Passport.Email.Exists',
+    'notNull': 'Error.Passport.Email.Missing'
+  },
+  'username': {
+    'string': 'Error.Passport.Username.Invalid',
+    'unique': 'Error.Passport.User.Exists',
+    'notNull': 'Error.Passport.Username.Missing'
+  },
+  'password': {
+    'string': 'Error.Passport.Password.Invalid',
+    'minLength': 'Error.Passport.Password.Short',
+  }
+}
+
+/**
+ * SAError
+ *
+ * Dress up an error to relay authentication/authorisation related errors
+ * without revealing sensitive information.
+ *
+ * @param  {Object} properties
+ * @constructor {SAError}
+ */
+function SAError (properties) {
+
+  // Call superclass (Error)
+  SAError.super_.call(this, properties);
+
+  // Merge the properties into the error instance
+  properties || (properties = { });
+  _.extend(this, properties);
+
+  // Customize the `reason` based on the # of invalid attributes
+  // (`reason` may not be overridden)
+  var isSingular = this.length === 1;
+  this.reason = util.format('%d attribute%s %s invalid',
+    this.length,
+    isSingular ? '' : 's',
+    isSingular ? 'is' : 'are');
+
+  // Always apply the 'E_VALIDATION' error code, even if it was overridden.
+  this.code = 'E_VALIDATION';
+
+  // Status may be overridden.
+  this.status = properties.status || 400;
+
+  if (this.originalError) {
+    if (this.originalError.invalidAttributes) {
+      this.invalidAttributes = _.mapValues(this.originalError.invalidAttributes, function(n, k) {
+        return _.map(n, function(i) {
+          // Set a new message if we have one
+          if (_.has(errors, [k, i.rule])) {
+            i.message = errors[k][i.rule];
+          }
+
+          // Remove all elements but the message
+          _.forEach(_.without(_.keys(i), 'message'), function(key) {
+            delete i[key];
+          })
+
+          return i;
+        })
+
+        return n;
+      });
+    }
+
+  }
+}
+
+util.inherits(SAError, Error);
+
+// Default properties
+SAError.prototype.status = 400;
+SAError.prototype.summary = 'Encountered an unexpected error';
+
+/**
+ * Override JSON serialization.
+ * (i.e. when this error is passed to `res.json()` or `JSON.stringify`)
+ *
+ * For example:
+ * ```json
+ * {
+ *   status: 400,
+ *   code: 'E_UNKNOWN'
+ * }
+ * ```
+ *
+ * @return {Object}
+ */
+SAError.prototype.toJSON =
+SAError.prototype.toPOJO =
+  function () {
+    var obj = {
+      status: this.status,
+      summary: this.summary,
+      invalidAttributes: this.invalidAttributes
+    };
+
+
+    return obj;
+  };
+
+
+module.exports = SAError;

--- a/test/unit/controllers/UserController.test.js
+++ b/test/unit/controllers/UserController.test.js
@@ -61,7 +61,7 @@ describe('User Controller', function () {
               email: 'new.user@email.com',
               password: 'admin1234'
             })
-            .expect(500)
+            .expect(400)
             .end(function (err) {
               done(err);
             });
@@ -87,7 +87,7 @@ describe('User Controller', function () {
 
         io.socket.post('/register', { email: 'new.socketuser@email.com', password: 'admin1234' }, function (data, jwres) {
 
-          assert.equal(jwres.statusCode, 500);
+          assert.equal(jwres.statusCode, 400);
           done();
 
         });


### PR DESCRIPTION
Added an error class to wrap the validation errors and return a waterline-styled error filtering out most of the information. I thought it's the simplest to try and match the waterline API as close as possible.

**This PR changes public API**

It is the first time I contribute to a nodejs module so if I have done something inconvenient do let me know. Also I have no clue how to solve the localisation of the error messages (I imagine some hook would be needed that has access to the request for the locale, but I couldn't figure out how to solve it, as I said - new to node/sails), if you can provide an explanation/resources of how is it supposed to work I'll be happy to do it.

Fixes #58 
