### PR TITLE
#107 sails.services.passport throwing issue

### DIFF
--- a/api/policies/passport.js
+++ b/api/policies/passport.js
@@ -27,7 +27,7 @@ var http = require('http');
 var methods = ['login', 'logIn', 'logout', 'logOut', 'isAuthenticated', 'isUnauthenticated'];
 
 module.exports = function (req, res, next) {
-  var passport = sails.services.passport;
+  var passport = require('passport');
 
   // Initialize Passport
   passport.initialize()(req, res, function () {


### PR DESCRIPTION
To solve this bug
TypeError: Cannot read property 'initialize' of undefined
    at module.exports (/Users/anas/projects/sharkfish-server/node_modules/sails-auth/dist/api/policies/passport.js:35:11)