### PR TITLE
Checking sails app baseUrl not strictly for null and undefined

### DIFF
--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -290,7 +290,7 @@ passport.loadStrategies = function () {
       Strategy = strategies[key].strategy;
 
       var baseUrl = '';
-      if (sails.config.appUrl !== null) {
+      if (sails.config.appUrl != null) {
         baseUrl = sails.config.appUrl
       }
       else {


### PR DESCRIPTION
Was failing when baseUrl was not set at all (case of `undefined`)
