### PR TITLE
allowing logged-in user to bind a passport without username or email

### DIFF
--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -64,8 +64,6 @@ passport.protocols = require('./protocols');
  * @param {Function} next
  */
 passport.connect = function (req, query, profile, next) {
-  var user = { };
-
   req.session.tokens = query.tokens;
 
   // Get the authentication provider from the query.
@@ -83,23 +81,6 @@ passport.connect = function (req, query, profile, next) {
 
   sails.log.debug('auth profile', profile);
 
-  // If the profile object contains a list of emails, grab the first one and
-  // add it to the user.
-  if (profile.emails && profile.emails[0]) {
-    user.email = profile.emails[0].value;
-  }
-  // If the profile object contains a username, add it to the user.
-  if (_.has(profile, 'username')) {
-    user.username = profile.username;
-  }
-
-  // If neither an email or a username was available in the profile, we don't
-  // have a way of identifying the user in the future. Throw an error and let
-  // whoever's next in the line take care of it.
-  if (!user.username && !user.email) {
-    return next(new Error('Neither a username nor email was available'));
-  }
-
   sails.models.passport.findOne({
       provider: provider,
       identifier: query.identifier.toString()
@@ -110,6 +91,24 @@ passport.connect = function (req, query, profile, next) {
         //           authentication provider.
         // Action:   Create a new user and assign them a passport.
         if (!passport) {
+          var user = { };
+          // If the profile object contains a list of emails, grab the first one and
+          // add it to the user.
+          if (profile.emails && profile.emails[0]) {
+            user.email = profile.emails[0].value;
+          }
+          // If the profile object contains a username, add it to the user.
+          if (_.has(profile, 'username')) {
+            user.username = profile.username;
+          }
+
+          // If neither an email or a username was available in the profile, we don't
+          // have a way of identifying the user in the future. Throw an error and let
+          // whoever's next in the line take care of it.
+          if (!user.username && !user.email) {
+            return next(new Error('Neither a username nor email was available'));
+          }
+
           return sails.models.user.create(user)
             .then(function (_user) {
               user = _user;


### PR DESCRIPTION
The reasoning behind this change is that we need unique user credentials provided in auth profile only for the case when there is no corresponding passport stored in DB and the current user is not authenticated. 

Live example: I am authenticated and I want to connect my facebook profile with my user, and facebook for some reason doesn't give me the email/username. Basically, I don't care for the email right now because the current user has a verified email already attached.
