### PR TITLE
Local Login : pass SAError when user identifier does not exist

### DIFF
--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -198,13 +198,9 @@ exports.login = function (req, identifier, password, next) {
     }
 
     if (!user) {
-      if (isEmail) {
-        req.flash('error', 'Error.Passport.Email.NotFound');
-      } else {
-        req.flash('error', 'Error.Passport.Username.NotFound');
-      }
-
-      return next(null, false);
+      var message = sails.__((isEmail) ? 'Error.Passport.Email.NotFound' : 'Error.Passport.Username.NotFound');
+      req.flash('error', message);
+      return next(new SAError({message}), false);
     }
 
     sails.models.passport.findOne({


### PR DESCRIPTION
Hi,

This PR passes SAError when user identifier does not exist in the callback function. This would be very helpful especially for debuging when req.flash is not used (API app). Currently, if user identifier does not exist the the request response and the console return both "null" on login.